### PR TITLE
feat: ChartEditorにJSON形式インポート機能を追加

### DIFF
--- a/JirouUnity/Assets/Tests/EditMode/Import.meta
+++ b/JirouUnity/Assets/Tests/EditMode/Import.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85ee1ce342847494a9dad56e0aa7e341
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/Tests/EditMode/Import/ChartConversionUtilityTests.cs
+++ b/JirouUnity/Assets/Tests/EditMode/Import/ChartConversionUtilityTests.cs
@@ -1,0 +1,87 @@
+using NUnit.Framework;
+using Jirou.Editor.Import;
+using Jirou.Core;
+
+namespace Jirou.Tests.Editor
+{
+    [TestFixture]
+    public class ChartConversionUtilityTests
+    {
+        [Test]
+        public void ConvertMillisecondsToBeats_正常な変換()
+        {
+            // BPM 120の場合、1ビート = 0.5秒 = 500ms
+            float result = ChartConversionUtility.ConvertMillisecondsToBeats(1000, 120f);
+            Assert.AreEqual(2f, result, 0.001f);
+        }
+        
+        [Test]
+        public void ConvertLPBToBeats_正常な変換()
+        {
+            // num=16, LPB=4 の場合、16/4 = 4ビート
+            float result = ChartConversionUtility.ConvertLPBToBeats(16, 4);
+            Assert.AreEqual(4f, result, 0.001f);
+        }
+        
+        [Test]
+        public void ConvertNoteType_Tapノーツ()
+        {
+            var result = ChartConversionUtility.ConvertNoteType(1);
+            Assert.AreEqual(NoteType.Tap, result);
+        }
+        
+        [Test]
+        public void ConvertNoteType_Holdノーツ()
+        {
+            var result = ChartConversionUtility.ConvertNoteType(2);
+            Assert.AreEqual(NoteType.Hold, result);
+        }
+        
+        [Test]
+        public void CalculateHoldDuration_正常な計算()
+        {
+            var startNote = new NotesEditorNote
+            {
+                LPB = 4,
+                num = 8,
+                type = 2,
+                notes = new System.Collections.Generic.List<object>
+                {
+                    new NotesEditorNote { LPB = 4, num = 16 }
+                }
+            };
+            
+            float result = ChartConversionUtility.CalculateHoldDuration(startNote);
+            Assert.AreEqual(2f, result, 0.001f); // (16-8)/4 = 2
+        }
+        
+        [Test]
+        public void CalculateHoldDuration_Tapノーツは0を返す()
+        {
+            var tapNote = new NotesEditorNote
+            {
+                LPB = 4,
+                num = 8,
+                type = 1,
+                notes = null
+            };
+            
+            float result = ChartConversionUtility.CalculateHoldDuration(tapNote);
+            Assert.AreEqual(0f, result, 0.001f);
+        }
+        
+        [Test]
+        public void ConvertMillisecondsToBeats_ゼロBPMは0を返す()
+        {
+            float result = ChartConversionUtility.ConvertMillisecondsToBeats(1000, 0f);
+            Assert.AreEqual(0f, result, 0.001f);
+        }
+        
+        [Test]
+        public void ConvertLPBToBeats_ゼロLPBは0を返す()
+        {
+            float result = ChartConversionUtility.ConvertLPBToBeats(16, 0);
+            Assert.AreEqual(0f, result, 0.001f);
+        }
+    }
+}

--- a/JirouUnity/Assets/Tests/EditMode/Import/ChartConversionUtilityTests.cs.meta
+++ b/JirouUnity/Assets/Tests/EditMode/Import/ChartConversionUtilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b98610d5057ee7f44b9354e809262966
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/Tests/EditMode/Import/ImportPerformanceTests.cs
+++ b/JirouUnity/Assets/Tests/EditMode/Import/ImportPerformanceTests.cs
@@ -1,0 +1,182 @@
+using System.Diagnostics;
+using NUnit.Framework;
+using Jirou.Editor.Import;
+using Debug = UnityEngine.Debug;
+
+namespace Jirou.Tests.Editor
+{
+    [TestFixture]
+    public class ImportPerformanceTests
+    {
+        [Test]
+        public void ImportLargeFile_パフォーマンス測定()
+        {
+            // 大量のノーツを含むテストデータを生成
+            var testData = GenerateLargeTestData(1000);
+            string json = UnityEngine.JsonUtility.ToJson(testData);
+            
+            var stopwatch = Stopwatch.StartNew();
+            
+            Jirou.Core.ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(json, out chartData, out error);
+            
+            stopwatch.Stop();
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(1000, chartData.Notes.Count);
+            
+            Debug.Log($"1000ノーツのインポート時間: {stopwatch.ElapsedMilliseconds}ms");
+            
+            // パフォーマンス基準: 1000ノーツで1秒以内
+            Assert.Less(stopwatch.ElapsedMilliseconds, 1000);
+            
+            UnityEngine.Object.DestroyImmediate(chartData);
+        }
+        
+        [Test]
+        public void ImportSmallFile_パフォーマンス測定()
+        {
+            // 少量のノーツを含むテストデータを生成
+            var testData = GenerateLargeTestData(10);
+            string json = UnityEngine.JsonUtility.ToJson(testData);
+            
+            var stopwatch = Stopwatch.StartNew();
+            
+            Jirou.Core.ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(json, out chartData, out error);
+            
+            stopwatch.Stop();
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(10, chartData.Notes.Count);
+            
+            Debug.Log($"10ノーツのインポート時間: {stopwatch.ElapsedMilliseconds}ms");
+            
+            // パフォーマンス基準: 10ノーツで100ms以内
+            Assert.Less(stopwatch.ElapsedMilliseconds, 100);
+            
+            UnityEngine.Object.DestroyImmediate(chartData);
+        }
+        
+        [Test]
+        public void ImportMediumFile_パフォーマンス測定()
+        {
+            // 中量のノーツを含むテストデータを生成
+            var testData = GenerateLargeTestData(100);
+            string json = UnityEngine.JsonUtility.ToJson(testData);
+            
+            var stopwatch = Stopwatch.StartNew();
+            
+            Jirou.Core.ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(json, out chartData, out error);
+            
+            stopwatch.Stop();
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(100, chartData.Notes.Count);
+            
+            Debug.Log($"100ノーツのインポート時間: {stopwatch.ElapsedMilliseconds}ms");
+            
+            // パフォーマンス基準: 100ノーツで200ms以内
+            Assert.Less(stopwatch.ElapsedMilliseconds, 200);
+            
+            UnityEngine.Object.DestroyImmediate(chartData);
+        }
+        
+        private NotesEditorData GenerateLargeTestData(int noteCount)
+        {
+            var data = new NotesEditorData
+            {
+                name = "Performance Test",
+                BPM = 120,
+                offset = 0,
+                notes = new System.Collections.Generic.List<NotesEditorNote>()
+            };
+            
+            for (int i = 0; i < noteCount; i++)
+            {
+                data.notes.Add(new NotesEditorNote
+                {
+                    LPB = 4,
+                    num = i * 4,
+                    block = i % 4,
+                    type = 1,
+                    notes = new System.Collections.Generic.List<object>()
+                });
+            }
+            
+            return data;
+        }
+        
+        [Test]
+        public void ImportWithComplexHolds_パフォーマンス測定()
+        {
+            // Holdノーツを含む複雑なテストデータを生成
+            var testData = GenerateComplexTestData(200);
+            string json = UnityEngine.JsonUtility.ToJson(testData);
+            
+            var stopwatch = Stopwatch.StartNew();
+            
+            Jirou.Core.ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(json, out chartData, out error);
+            
+            stopwatch.Stop();
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(200, chartData.Notes.Count);
+            
+            Debug.Log($"200個の複雑なノーツのインポート時間: {stopwatch.ElapsedMilliseconds}ms");
+            
+            // パフォーマンス基準: 200個の複雑なノーツで500ms以内
+            Assert.Less(stopwatch.ElapsedMilliseconds, 500);
+            
+            UnityEngine.Object.DestroyImmediate(chartData);
+        }
+        
+        private NotesEditorData GenerateComplexTestData(int noteCount)
+        {
+            var data = new NotesEditorData
+            {
+                name = "Complex Performance Test",
+                BPM = 150,
+                offset = 2000,
+                notes = new System.Collections.Generic.List<NotesEditorNote>()
+            };
+            
+            for (int i = 0; i < noteCount; i++)
+            {
+                // TapとHoldを交互に配置
+                bool isHold = i % 2 == 0;
+                var note = new NotesEditorNote
+                {
+                    LPB = 4,
+                    num = i * 4,
+                    block = i % 4,
+                    type = isHold ? 2 : 1,
+                    notes = new System.Collections.Generic.List<object>()
+                };
+                
+                // Holdノーツの場合、終了位置を追加
+                if (isHold)
+                {
+                    note.notes.Add(new NotesEditorNote
+                    {
+                        LPB = 4,
+                        num = (i + 1) * 4,
+                        block = i % 4,
+                        type = 2,
+                        notes = new System.Collections.Generic.List<object>()
+                    });
+                }
+                
+                data.notes.Add(note);
+            }
+            
+            return data;
+        }
+    }
+}

--- a/JirouUnity/Assets/Tests/EditMode/Import/ImportPerformanceTests.cs.meta
+++ b/JirouUnity/Assets/Tests/EditMode/Import/ImportPerformanceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 802e8d56007a4d64bb5d28f7778a23d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/Tests/EditMode/Import/NotesEditorImportIntegrationTests.cs
+++ b/JirouUnity/Assets/Tests/EditMode/Import/NotesEditorImportIntegrationTests.cs
@@ -1,0 +1,199 @@
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEditor;
+using Jirou.Core;
+using Jirou.Editor.Import;
+
+namespace Jirou.Tests.Editor
+{
+    [TestFixture]
+    public class NotesEditorImportIntegrationTests
+    {
+        private string testDataPath;
+        
+        [SetUp]
+        public void Setup()
+        {
+            // テストデータのパスを設定
+            testDataPath = Path.Combine(Application.dataPath, 
+                "_Jirou/Data/ChartsJson/End_Time.json");
+        }
+        
+        [Test]
+        public void ImportNotesEditorJson_完全なファイル()
+        {
+            // ファイルが存在することを確認
+            Assert.IsTrue(File.Exists(testDataPath), 
+                $"テストファイルが見つかりません: {testDataPath}");
+            
+            // JSONを読み込み
+            string json = File.ReadAllText(testDataPath);
+            
+            // インポート実行
+            ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(json, out chartData, out error);
+            
+            // 検証
+            Assert.IsTrue(success, $"インポート失敗: {error}");
+            Assert.IsNotNull(chartData);
+            Assert.AreEqual("End_Time", chartData.SongName);
+            Assert.AreEqual(180f, chartData.Bpm);
+            Assert.Greater(chartData.Notes.Count, 0);
+            
+            // 後処理
+            Object.DestroyImmediate(chartData);
+        }
+        
+        [Test]
+        public void ImportNotesEditorJson_ノーツ変換確認()
+        {
+            string simpleJson = @"{
+                ""name"": ""Test"",
+                ""BPM"": 120,
+                ""offset"": 0,
+                ""notes"": [
+                    {
+                        ""LPB"": 4,
+                        ""num"": 8,
+                        ""block"": 1,
+                        ""type"": 1,
+                        ""notes"": []
+                    }
+                ]
+            }";
+            
+            ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(simpleJson, out chartData, out error);
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(1, chartData.Notes.Count);
+            
+            var note = chartData.Notes[0];
+            Assert.AreEqual(1, note.LaneIndex);
+            Assert.AreEqual(NoteType.Tap, note.NoteType);
+            Assert.AreEqual(2f, note.TimeToHit); // 8/4 = 2
+            
+            Object.DestroyImmediate(chartData);
+        }
+        
+        [Test]
+        public void ImportNotesEditorJson_Holdノーツ変換()
+        {
+            string holdJson = @"{
+                ""name"": ""Test"",
+                ""BPM"": 120,
+                ""offset"": 0,
+                ""notes"": [
+                    {
+                        ""LPB"": 4,
+                        ""num"": 0,
+                        ""block"": 2,
+                        ""type"": 2,
+                        ""notes"": [
+                            {
+                                ""LPB"": 4,
+                                ""num"": 16,
+                                ""block"": 2,
+                                ""type"": 2,
+                                ""notes"": []
+                            }
+                        ]
+                    }
+                ]
+            }";
+            
+            ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(holdJson, out chartData, out error);
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(1, chartData.Notes.Count);
+            
+            var note = chartData.Notes[0];
+            Assert.AreEqual(NoteType.Hold, note.NoteType);
+            Assert.AreEqual(4f, note.HoldDuration); // (16-0)/4 = 4
+            
+            Object.DestroyImmediate(chartData);
+        }
+        
+        [Test]
+        public void ImportNotesEditorJson_無効なデータ()
+        {
+            string invalidJson = @"{
+                ""name"": ""Test"",
+                ""BPM"": -120,
+                ""offset"": 0,
+                ""notes"": []
+            }";
+            
+            ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(invalidJson, out chartData, out error);
+            
+            Assert.IsFalse(success);
+            Assert.IsNotNull(error);
+            Assert.IsNull(chartData);
+        }
+        
+        [Test]
+        public void ImportNotesEditorJson_複数のノーツ()
+        {
+            string multipleNotesJson = @"{
+                ""name"": ""Test"",
+                ""BPM"": 120,
+                ""offset"": 1000,
+                ""notes"": [
+                    {
+                        ""LPB"": 4,
+                        ""num"": 0,
+                        ""block"": 0,
+                        ""type"": 1,
+                        ""notes"": []
+                    },
+                    {
+                        ""LPB"": 4,
+                        ""num"": 4,
+                        ""block"": 1,
+                        ""type"": 1,
+                        ""notes"": []
+                    },
+                    {
+                        ""LPB"": 4,
+                        ""num"": 8,
+                        ""block"": 2,
+                        ""type"": 1,
+                        ""notes"": []
+                    },
+                    {
+                        ""LPB"": 4,
+                        ""num"": 12,
+                        ""block"": 3,
+                        ""type"": 1,
+                        ""notes"": []
+                    }
+                ]
+            }";
+            
+            ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(multipleNotesJson, out chartData, out error);
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(4, chartData.Notes.Count);
+            
+            // オフセットが正しく変換されているか確認
+            Assert.AreEqual(2f, chartData.FirstBeatOffset); // 1000ms at 120BPM = 2 beats
+            
+            // レーンが正しく設定されているか確認
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.AreEqual(i, chartData.Notes[i].LaneIndex);
+            }
+            
+            Object.DestroyImmediate(chartData);
+        }
+    }
+}

--- a/JirouUnity/Assets/Tests/EditMode/Import/NotesEditorImportIntegrationTests.cs.meta
+++ b/JirouUnity/Assets/Tests/EditMode/Import/NotesEditorImportIntegrationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1847bf0f3f96954db99ff648e2df156
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/Tests/EditMode/Jirou.EditModeTests.asmdef
+++ b/JirouUnity/Assets/Tests/EditMode/Jirou.EditModeTests.asmdef
@@ -7,7 +7,8 @@
         "Jirou.Core",
         "Jirou.Gameplay",
         "Jirou.UI",
-        "Jirou.Visual"
+        "Jirou.Visual",
+        "Jirou.Editor"
     ],
     "includePlatforms": [
         "Editor"

--- a/JirouUnity/Assets/_Jirou/Data/Charts/TestChart.asset
+++ b/JirouUnity/Assets/_Jirou/Data/Charts/TestChart.asset
@@ -21,170 +21,1530 @@ MonoBehaviour:
   _difficulty: 1
   _difficultyName: Normal
   _notes:
-  - _noteType: 1
-    _laneIndex: 0
-    _timeToHit: 0
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 1
-    _timeToHit: 0.5
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 1
-    _laneIndex: 2
-    _timeToHit: 1
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 3
-    _timeToHit: 1.5
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 0
-    _timeToHit: 4
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 1
-    _timeToHit: 4.5
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 2
-    _timeToHit: 5
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 3
-    _timeToHit: 5.5
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 1
-    _laneIndex: 0
-    _timeToHit: 8
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 1
-    _timeToHit: 8.5
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 1
-    _laneIndex: 2
-    _timeToHit: 9
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 3
-    _timeToHit: 9.5
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 0
-    _timeToHit: 12
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 1
-    _timeToHit: 12.5
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 2
-    _timeToHit: 13
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
-  - _noteType: 0
-    _laneIndex: 3
-    _timeToHit: 13.5
-    _holdDuration: 2
-    _visualScale: 1
-    _noteColor: {r: 1, g: 1, b: 1, a: 1}
-    _customHitSound: {fileID: 0}
-    _customHitEffect: {fileID: 0}
-    _baseScore: 100
-    _scoreMultiplier: 1
   - _noteType: 0
     _laneIndex: 0
     _timeToHit: 0
     _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 4
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 8
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 12
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 16
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 20
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 24
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 36
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 37
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 38
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 39
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 40
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 41
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 42
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 43
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 44
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 45
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 46
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 47
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 48
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 49
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 50
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 51
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 52
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 53
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 54
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 55
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 56
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 57
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 58
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 59
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 60
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 60
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 61
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 61
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 62
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 62
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 63
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 63
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 64
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 64
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 65
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 65.5
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 66
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 67
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 0
+    _timeToHit: 68
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 1
+    _timeToHit: 72
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 2
+    _timeToHit: 76
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 3
+    _timeToHit: 80
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 0
+    _timeToHit: 84
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 1
+    _timeToHit: 88
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 93
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 94
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 95
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 3
+    _timeToHit: 96
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 1
+    _timeToHit: 96
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 100
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 100
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 104
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 108
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 112
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 116
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 120
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 122
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 124
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 1
+    _timeToHit: 128
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 3
+    _timeToHit: 128
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 132
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 134
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 136
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 138
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 140
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 144
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 146
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 3
+    _timeToHit: 148
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 151.5
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 151.75
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 152
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 154
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 156
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 156
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 160
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 164
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 165
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 166
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 167
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 168
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 169
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 170
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 171
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 172
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 173
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 174
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 175
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 176
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 177
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 178
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 179
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 180
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 181
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 182
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 183
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 184
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 185
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 186
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 187
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 188
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 189
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 190
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 191
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 192
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 2
+    _timeToHit: 192
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 193
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 1
+    _timeToHit: 194
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 194
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 195
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 196
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 0
+    _timeToHit: 196
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 197
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 198
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 1
+    _timeToHit: 198
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 199
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 200
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 200
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 201
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 202
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 203
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 204
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 204
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 205
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 206
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 207
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 0
+    _timeToHit: 208
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 208
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 209
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 210
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 211
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 3
+    _timeToHit: 212
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 213
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 214
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 215
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 2
+    _timeToHit: 216
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 217
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 218
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 1
+    _timeToHit: 219
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 220
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 221
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 222
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 0
+    _laneIndex: 0
+    _timeToHit: 223
+    _holdDuration: 0
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 0
+    _timeToHit: 224
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 1
+    _timeToHit: 224
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 2
+    _timeToHit: 224
+    _holdDuration: 1
+    _visualScale: 1
+    _noteColor: {r: 1, g: 1, b: 1, a: 1}
+    _customHitSound: {fileID: 0}
+    _customHitEffect: {fileID: 0}
+    _baseScore: 100
+    _scoreMultiplier: 1
+  - _noteType: 1
+    _laneIndex: 3
+    _timeToHit: 224
+    _holdDuration: 1
     _visualScale: 1
     _noteColor: {r: 1, g: 1, b: 1, a: 1}
     _customHitSound: {fileID: 0}

--- a/JirouUnity/Assets/_Jirou/Data/ChartsJson.meta
+++ b/JirouUnity/Assets/_Jirou/Data/ChartsJson.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a79682d80802db4f92addc5f9e7d8ec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/_Jirou/Data/ChartsJson/End_Time.json
+++ b/JirouUnity/Assets/_Jirou/Data/ChartsJson/End_Time.json
@@ -1,0 +1,1246 @@
+﻿{
+  "name": "End_Time",
+  "maxBlock": 5,
+  "BPM": 180,
+  "offset": 29800,
+  "notes": [
+    {
+      "LPB": 4,
+      "num": 0,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 16,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 32,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 48,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 64,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 80,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 96,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 144,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 148,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 152,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 156,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 160,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 164,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 168,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 172,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 176,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 180,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 184,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 188,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 192,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 196,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 200,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 204,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 208,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 212,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 216,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 220,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 224,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 228,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 232,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 236,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 240,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 240,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 244,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 244,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 248,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 248,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 252,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 252,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 256,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 256,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 260,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 262,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 264,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 268,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 272,
+      "block": 0,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 288,
+          "block": 0,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 288,
+      "block": 1,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 304,
+          "block": 1,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 304,
+      "block": 2,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 320,
+          "block": 2,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 320,
+      "block": 3,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 352,
+          "block": 3,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 336,
+      "block": 0,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 352,
+          "block": 0,
+          "type": 2,
+          "notes": []
+        },
+        {
+          "LPB": 4,
+          "num": 384,
+          "block": 0,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 352,
+      "block": 1,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 368,
+          "block": 1,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 372,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 376,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 380,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 384,
+      "block": 3,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 400,
+          "block": 3,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 384,
+      "block": 1,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 400,
+          "block": 1,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 400,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 400,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 416,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 432,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 448,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 464,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 480,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 488,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 496,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 512,
+      "block": 3,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 528,
+          "block": 3,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 512,
+      "block": 1,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 528,
+          "block": 1,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 528,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 536,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 544,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 552,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 560,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 576,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 584,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 592,
+      "block": 3,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 604,
+          "block": 3,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 606,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 607,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 608,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 616,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 624,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 624,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 640,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 656,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 660,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 664,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 668,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 672,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 676,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 680,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 684,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 688,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 692,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 696,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 700,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 704,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 708,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 712,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 716,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 720,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 724,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 728,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 732,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 736,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 740,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 744,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 748,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 752,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 756,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 760,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 764,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 768,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 768,
+      "block": 2,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 776,
+          "block": 2,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 772,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 776,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 776,
+      "block": 1,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 784,
+          "block": 1,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 780,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 784,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 784,
+      "block": 0,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 792,
+          "block": 0,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 788,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 792,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 792,
+      "block": 1,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 800,
+          "block": 1,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 796,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 800,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 800,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 804,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 808,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 812,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 816,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 816,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 820,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 824,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 828,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 832,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 832,
+      "block": 0,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 848,
+          "block": 0,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 836,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 840,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 844,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 848,
+      "block": 3,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 852,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 856,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 860,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 864,
+      "block": 2,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 868,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 872,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 876,
+      "block": 1,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 880,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 884,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 888,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 892,
+      "block": 0,
+      "type": 1,
+      "notes": []
+    },
+    {
+      "LPB": 4,
+      "num": 896,
+      "block": 0,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 912,
+          "block": 0,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 896,
+      "block": 1,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 912,
+          "block": 1,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 896,
+      "block": 2,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 912,
+          "block": 2,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    },
+    {
+      "LPB": 4,
+      "num": 896,
+      "block": 3,
+      "type": 2,
+      "notes": [
+        {
+          "LPB": 4,
+          "num": 912,
+          "block": 3,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    }
+  ]
+}

--- a/JirouUnity/Assets/_Jirou/Data/ChartsJson/End_Time.json.meta
+++ b/JirouUnity/Assets/_Jirou/Data/ChartsJson/End_Time.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d78ad5fb8d4d26a4d82eae2bb241cf55
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/_Jirou/Scenes/GameScene.unity
+++ b/JirouUnity/Assets/_Jirou/Scenes/GameScene.unity
@@ -385,7 +385,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2b6a29f2fb0ee794db2e2c3dec5049f1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  chartData: {fileID: 0}
+  chartData: {fileID: 11400000, guid: 29454d8cca861d14fb27ee717475adaa, type: 2}
   tapNotePrefab: {fileID: 2290750175035262268, guid: 665bcf0debb010e4ba70a514528809d7,
     type: 3}
   holdNotePrefab: {fileID: 6330483975887224903, guid: da7d490c4fd7638489186d77ebc45ec1,
@@ -474,7 +474,7 @@ MonoBehaviour:
   enableLOD: 1
   lodDistance: 10
   lodQualityReduction: 0.5
-  showDebugInfo: 1
+  showDebugInfo: 0
 --- !u!1 &613380370
 GameObject:
   m_ObjectHideFlags: 0
@@ -1234,7 +1234,7 @@ MonoBehaviour:
     color: {r: 1, g: 0, b: 0, a: 1}
     scale: 0.9
   poolSize: 20
-  showDebugInfo: 1
+  showDebugInfo: 0
 --- !u!1 &2024498305
 GameObject:
   m_ObjectHideFlags: 0
@@ -1265,7 +1265,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   autoSetup: 1
-  generateTestChart: 1
+  generateTestChart: 0
   testBPM: 180
   noteCount: 20
   noteInterval: 1

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import.meta
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80eb6e3c8a8050048b20754fa8a24f12
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ChartConversionUtility.cs
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ChartConversionUtility.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// 譜面データ変換ユーティリティ
+    /// </summary>
+    public static class ChartConversionUtility
+    {
+        /// <summary>
+        /// ミリ秒オフセットをビート単位に変換
+        /// </summary>
+        public static float ConvertMillisecondsToBeats(int offsetMs, float bpm)
+        {
+            if (bpm <= 0) return 0f;
+            
+            float offsetSeconds = offsetMs / 1000f;
+            float beatDuration = 60f / bpm;
+            return offsetSeconds / beatDuration;
+        }
+        
+        /// <summary>
+        /// LPB単位のタイミングをビート単位に変換
+        /// </summary>
+        public static float ConvertLPBToBeats(int num, int lpb)
+        {
+            if (lpb <= 0) return 0f;
+            return (float)num / lpb;
+        }
+        
+        /// <summary>
+        /// ノーツタイプを変換
+        /// </summary>
+        public static NoteType ConvertNoteType(int type)
+        {
+            return type == 2 ? NoteType.Hold : NoteType.Tap;
+        }
+        
+        /// <summary>
+        /// Holdノーツの継続時間を計算
+        /// </summary>
+        public static float CalculateHoldDuration(NotesEditorNote startNote)
+        {
+            // 現在のJSONフォーマットではHoldノーツの終端位置が含まれていないため
+            // デフォルトの長さを返す
+            if (startNote.type != 2)
+            {
+                return 0f;
+            }
+            
+            // Holdノーツのデフォルト長さ（1ビート）
+            return 1.0f;
+        }
+    }
+}

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ChartConversionUtility.cs.meta
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ChartConversionUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f79b23ad9a7ff334598fed8c209fb51c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ChartImportManager.cs
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ChartImportManager.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// 譜面インポート管理クラス
+    /// </summary>
+    public static class ChartImportManager
+    {
+        private static readonly List<IChartImporter> importers = new List<IChartImporter>();
+        
+        static ChartImportManager()
+        {
+            // インポーターを登録
+            RegisterImporter(new NotesEditorJsonImporter());
+            // 将来的に他のインポーターも追加
+        }
+        
+        /// <summary>
+        /// インポーターを登録
+        /// </summary>
+        public static void RegisterImporter(IChartImporter importer)
+        {
+            if (importer != null && !importers.Contains(importer))
+            {
+                importers.Add(importer);
+                Debug.Log($"インポーター登録: {importer.GetFormatName()}");
+            }
+        }
+        
+        /// <summary>
+        /// インポートを試行
+        /// </summary>
+        public static bool TryImport(string content, out ChartData chartData, out string error)
+        {
+            chartData = null;
+            error = null;
+            
+            // 対応可能なインポーターを探す
+            foreach (var importer in importers)
+            {
+                if (importer.CanImport(content))
+                {
+                    try
+                    {
+                        Debug.Log($"{importer.GetFormatName()}形式として認識しました");
+                        chartData = importer.Import(content);
+                        return true;
+                    }
+                    catch (Exception e)
+                    {
+                        error = $"{importer.GetFormatName()}のインポート失敗:\n{e.Message}";
+                        Debug.LogError(error);
+                    }
+                }
+            }
+            
+            // 対応するインポーターが見つからない場合
+            error = "対応するインポート形式が見つかりませんでした。\n" +
+                   $"対応形式: {string.Join(", ", GetSupportedFormats())}";
+            return false;
+        }
+        
+        /// <summary>
+        /// サポートされている形式を取得
+        /// </summary>
+        public static string[] GetSupportedFormats()
+        {
+            return importers.Select(i => i.GetFormatName()).ToArray();
+        }
+        
+        /// <summary>
+        /// フォーマットを自動検出
+        /// </summary>
+        public static string DetectFormat(string content)
+        {
+            foreach (var importer in importers)
+            {
+                if (importer.CanImport(content))
+                {
+                    return importer.GetFormatName();
+                }
+            }
+            return "Unknown";
+        }
+    }
+}

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ChartImportManager.cs.meta
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ChartImportManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b5a5959f76dc624d9797f45b8375cdd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/IChartImporter.cs
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/IChartImporter.cs
@@ -1,0 +1,25 @@
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// 譜面インポーターのインターフェース
+    /// </summary>
+    public interface IChartImporter
+    {
+        /// <summary>
+        /// フォーマット名を取得
+        /// </summary>
+        string GetFormatName();
+        
+        /// <summary>
+        /// このインポーターが対応可能か判定
+        /// </summary>
+        bool CanImport(string content);
+        
+        /// <summary>
+        /// インポート実行
+        /// </summary>
+        ChartData Import(string content);
+    }
+}

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/IChartImporter.cs.meta
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/IChartImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f533f665f1f6f5b45bc4cf4132dca190
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ImportPreviewDialog.cs
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ImportPreviewDialog.cs
@@ -1,0 +1,140 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// インポートプレビューダイアログ
+    /// </summary>
+    public class ImportPreviewDialog : EditorWindow
+    {
+        private string jsonContent;
+        private string detectedFormat;
+        private ChartData previewData;
+        private Vector2 scrollPosition;
+        private bool showJsonContent = false;
+        private List<string> validationMessages = new List<string>();
+        private System.Action<ChartData> onImportCallback;
+        
+        public static void ShowDialog(string json, System.Action<ChartData> onImport)
+        {
+            var window = GetWindow<ImportPreviewDialog>("譜面インポート プレビュー");
+            window.minSize = new Vector2(500, 400);
+            window.jsonContent = json;
+            window.onImportCallback = onImport;
+            window.AnalyzeContent();
+        }
+        
+        private void AnalyzeContent()
+        {
+            detectedFormat = ChartImportManager.DetectFormat(jsonContent);
+            
+            // プレビュー用にインポートを試行
+            string error;
+            if (ChartImportManager.TryImport(jsonContent, out previewData, out error))
+            {
+                validationMessages.Add($"✓ {previewData.Notes.Count}個のノーツを検出");
+                validationMessages.Add($"✓ BPM: {previewData.Bpm}");
+                validationMessages.Add($"✓ 曲名: {previewData.SongName}");
+            }
+            else
+            {
+                validationMessages.Add($"✗ {error}");
+            }
+        }
+        
+        void OnGUI()
+        {
+            EditorGUILayout.LabelField("インポート形式", detectedFormat);
+            EditorGUILayout.Space();
+            
+            // プレビュー情報
+            if (previewData != null)
+            {
+                DrawPreviewInfo();
+            }
+            
+            // JSONコンテンツの表示/非表示
+            showJsonContent = EditorGUILayout.Foldout(showJsonContent, "JSONコンテンツ");
+            if (showJsonContent)
+            {
+                DrawJsonContent();
+            }
+            
+            // 検証結果
+            DrawValidationResults();
+            
+            // ボタン
+            DrawButtons();
+        }
+        
+        private void DrawPreviewInfo()
+        {
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+            EditorGUILayout.LabelField("譜面情報プレビュー", EditorStyles.boldLabel);
+            
+            EditorGUILayout.LabelField($"曲名: {previewData.SongName}");
+            EditorGUILayout.LabelField($"BPM: {previewData.Bpm}");
+            EditorGUILayout.LabelField($"ノーツ数: {previewData.Notes.Count}");
+            
+            var stats = previewData.GetStatistics();
+            EditorGUILayout.LabelField($"Tapノーツ: {stats.tapNotes}");
+            EditorGUILayout.LabelField($"Holdノーツ: {stats.holdNotes}");
+            
+            EditorGUILayout.EndVertical();
+        }
+        
+        private void DrawJsonContent()
+        {
+            scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition, GUILayout.Height(150));
+            EditorGUILayout.TextArea(jsonContent, GUILayout.ExpandHeight(true));
+            EditorGUILayout.EndScrollView();
+        }
+        
+        private void DrawValidationResults()
+        {
+            if (validationMessages.Count > 0)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("検証結果", EditorStyles.boldLabel);
+                
+                foreach (var msg in validationMessages)
+                {
+                    var style = msg.StartsWith("✓") ? EditorStyles.label : EditorStyles.helpBox;
+                    EditorGUILayout.LabelField(msg, style);
+                }
+            }
+        }
+        
+        private void DrawButtons()
+        {
+            EditorGUILayout.Space();
+            EditorGUILayout.BeginHorizontal();
+            
+            GUI.enabled = previewData != null;
+            if (GUILayout.Button("インポート", GUILayout.Height(30)))
+            {
+                // インポート実行
+                if (onImportCallback != null)
+                {
+                    onImportCallback(previewData);
+                }
+                Close();
+            }
+            GUI.enabled = true;
+            
+            if (GUILayout.Button("キャンセル", GUILayout.Height(30)))
+            {
+                if (previewData != null)
+                {
+                    DestroyImmediate(previewData);
+                }
+                Close();
+            }
+            
+            EditorGUILayout.EndHorizontal();
+        }
+    }
+}

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ImportPreviewDialog.cs.meta
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/ImportPreviewDialog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c31c3bffbf6f5e47a1ff36b928e16b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/NotesEditorData.cs
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/NotesEditorData.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// NotesEditor形式のJSONデータ構造
+    /// </summary>
+    [Serializable]
+    public class NotesEditorData
+    {
+        public string name;           // 曲名
+        public int maxBlock;         // 最大ブロック数
+        public float BPM;            // BPM
+        public int offset;           // オフセット（ミリ秒）
+        public List<NotesEditorNote> notes;  // ノーツリスト
+    }
+    
+    /// <summary>
+    /// NotesEditor形式のノーツデータ
+    /// </summary>
+    [Serializable]
+    public class NotesEditorNote
+    {
+        public int LPB;              // Lines Per Beat
+        public int num;              // タイミング（LPB単位）
+        public int block;            // レーン番号（0-3）
+        public int type;             // ノーツタイプ（1=Tap, 2=Hold）
+        public List<object> notes;   // Holdノーツの終了位置（通常は空配列）
+    }
+}

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/NotesEditorData.cs.meta
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/NotesEditorData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d86cf70a696a37645b4f153b818247eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/NotesEditorJsonImporter.cs
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/NotesEditorJsonImporter.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// NotesEditor形式のJSONインポーター
+    /// </summary>
+    public class NotesEditorJsonImporter : IChartImporter
+    {
+        public string GetFormatName() => "NotesEditor JSON";
+        
+        public bool CanImport(string json)
+        {
+            try
+            {
+                var data = JsonUtility.FromJson<NotesEditorData>(json);
+                return data != null && 
+                       data.notes != null && 
+                       !string.IsNullOrEmpty(data.name);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        
+        public ChartData Import(string json)
+        {
+            // JSONをパース
+            var notesEditorData = ParseJson(json);
+            
+            // データを検証
+            ValidateData(notesEditorData);
+            
+            // ChartDataに変換
+            return ConvertToChartData(notesEditorData);
+        }
+        
+        private NotesEditorData ParseJson(string json)
+        {
+            try
+            {
+                var data = JsonUtility.FromJson<NotesEditorData>(json);
+                if (data == null)
+                {
+                    throw new ImportException("JSONの解析に失敗しました");
+                }
+                return data;
+            }
+            catch (Exception e)
+            {
+                throw new ImportException($"JSONパースエラー: {e.Message}");
+            }
+        }
+        
+        private void ValidateData(NotesEditorData data)
+        {
+            var errors = new List<string>();
+            
+            // BPMの検証
+            if (data.BPM <= 0 || data.BPM > 999)
+            {
+                errors.Add($"無効なBPM値: {data.BPM}");
+            }
+            
+            // ノーツの検証
+            if (data.notes == null)
+            {
+                errors.Add("ノーツデータが存在しません");
+            }
+            else
+            {
+                foreach (var note in data.notes)
+                {
+                    if (note.block < 0 || note.block > 3)
+                    {
+                        errors.Add($"無効なレーン番号: {note.block} (タイミング: {note.num})");
+                    }
+                    
+                    if (note.type != 1 && note.type != 2)
+                    {
+                        errors.Add($"無効なノーツタイプ: {note.type} (タイミング: {note.num})");
+                    }
+                    
+                    if (note.LPB <= 0)
+                    {
+                        errors.Add($"無効なLPB値: {note.LPB} (タイミング: {note.num})");
+                    }
+                }
+            }
+            
+            if (errors.Count > 0)
+            {
+                throw new ImportException(string.Join("\n", errors));
+            }
+        }
+        
+        private ChartData ConvertToChartData(NotesEditorData data)
+        {
+            // 新しいChartDataアセットを作成
+            var chartData = ScriptableObject.CreateInstance<ChartData>();
+            
+            // SerializedObjectを使用してプライベートフィールドを設定
+            var so = new SerializedObject(chartData);
+            
+            try
+            {
+                // 基本情報の設定
+                SetChartMetadata(so, data);
+                
+                // ノーツデータの変換と追加（SerializedObjectを渡す）
+                ConvertAndAddNotes(so, data.notes);
+                
+                // 変更を適用
+                so.ApplyModifiedPropertiesWithoutUndo();
+                
+                // ノーツをソート
+                chartData.SortNotesByTime();
+                
+                return chartData;
+            }
+            catch (Exception e)
+            {
+                // エラー時はアセットを破棄
+                UnityEngine.Object.DestroyImmediate(chartData);
+                throw new ImportException($"ChartData変換エラー: {e.Message}");
+            }
+        }
+        
+        private void SetChartMetadata(SerializedObject so, NotesEditorData data)
+        {
+            // 基本情報の設定
+            so.FindProperty("_songName").stringValue = data.name;
+            so.FindProperty("_bpm").floatValue = data.BPM;
+            
+            // オフセットをビート単位に変換
+            float offsetBeats = ChartConversionUtility.ConvertMillisecondsToBeats(data.offset, data.BPM);
+            so.FindProperty("_firstBeatOffset").floatValue = offsetBeats;
+            
+            // デフォルト値の設定
+            so.FindProperty("_artist").stringValue = "Unknown Artist";
+            so.FindProperty("_difficulty").intValue = 5;
+            so.FindProperty("_difficultyName").stringValue = "Normal";
+            so.FindProperty("_chartAuthor").stringValue = "Imported";
+            so.FindProperty("_chartVersion").stringValue = "1.0";
+        }
+        
+        private void ConvertAndAddNotes(SerializedObject so, List<NotesEditorNote> notesEditorNotes)
+        {
+            // _notesフィールドを取得
+            var notesProperty = so.FindProperty("_notes");
+            
+            // 既存のノーツをクリア
+            notesProperty.ClearArray();
+            
+            // 新しいノーツを追加
+            int noteIndex = 0;
+            foreach (var notesEditorNote in notesEditorNotes)
+            {
+                var noteData = ConvertNote(notesEditorNote);
+                if (noteData != null)
+                {
+                    notesProperty.InsertArrayElementAtIndex(noteIndex);
+                    var noteProperty = notesProperty.GetArrayElementAtIndex(noteIndex);
+                    
+                    // NoteDataの各フィールドを設定
+                    noteProperty.FindPropertyRelative("_laneIndex").intValue = noteData.LaneIndex;
+                    noteProperty.FindPropertyRelative("_noteType").enumValueIndex = (int)noteData.NoteType;
+                    noteProperty.FindPropertyRelative("_timeToHit").floatValue = noteData.TimeToHit;
+                    noteProperty.FindPropertyRelative("_holdDuration").floatValue = noteData.HoldDuration;
+                    noteProperty.FindPropertyRelative("_visualScale").floatValue = noteData.VisualScale;
+                    noteProperty.FindPropertyRelative("_noteColor").colorValue = noteData.NoteColor;
+                    noteProperty.FindPropertyRelative("_baseScore").intValue = noteData.BaseScore;
+                    noteProperty.FindPropertyRelative("_scoreMultiplier").floatValue = noteData.ScoreMultiplier;
+                    
+                    noteIndex++;
+                }
+            }
+            
+            Debug.Log($"インポート完了: {noteIndex}個のノーツを変換しました");
+        }
+        
+        private NoteData ConvertNote(NotesEditorNote notesEditorNote)
+        {
+            var noteData = new NoteData();
+            
+            // 基本プロパティの設定
+            noteData.LaneIndex = notesEditorNote.block;
+            noteData.NoteType = ChartConversionUtility.ConvertNoteType(notesEditorNote.type);
+            noteData.TimeToHit = ChartConversionUtility.ConvertLPBToBeats(notesEditorNote.num, notesEditorNote.LPB);
+            
+            // Holdノーツの場合、duration計算
+            if (noteData.NoteType == NoteType.Hold)
+            {
+                noteData.HoldDuration = ChartConversionUtility.CalculateHoldDuration(notesEditorNote);
+            }
+            
+            // デフォルト値の設定
+            noteData.VisualScale = 1.0f;
+            noteData.NoteColor = Color.white;
+            noteData.BaseScore = 100;
+            noteData.ScoreMultiplier = 1.0f;
+            
+            return noteData;
+        }
+    }
+    
+    /// <summary>
+    /// インポート例外クラス
+    /// </summary>
+    public class ImportException : Exception
+    {
+        public ImportException(string message) : base(message) { }
+    }
+}

--- a/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/NotesEditorJsonImporter.cs.meta
+++ b/JirouUnity/Assets/_Jirou/Scripts/Editor/Import/NotesEditorJsonImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee3327d2e8634e5448a1a5739657fea5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/architectures/chart-editor-json-import-design.md
+++ b/docs/architectures/chart-editor-json-import-design.md
@@ -1,0 +1,659 @@
+# ChartEditor JSON インポート機能 詳細設計書
+
+## 概要
+
+本書は、既存の外部JSON形式（NotesEditor形式）の譜面データを、JirouプロジェクトのChartDataフォーマットに変換・インポートする機能の詳細設計を定義します。
+
+## 背景と目的
+
+### 背景
+- 既存の譜面データ（End_Time.json等）が外部ツールで作成されている
+- 現在のChartEditorのインポート機能は独自フォーマットのみサポート
+- 外部譜面データの活用により、コンテンツ制作効率を向上させる必要がある
+
+### 目的
+1. 外部JSON形式の譜面データをChartDataに変換する機能の提供
+2. 複数の譜面フォーマットに対応可能な拡張性のある設計
+3. データ変換時の整合性チェックとエラーハンドリング
+
+## 外部JSON形式の分析
+
+### NotesEditor形式の構造
+
+```json
+{
+  "name": "End_Time",           // 曲名（楽曲名）
+  "maxBlock": 5,                // 最大ブロック数（未使用）
+  "BPM": 180,                   // BPM値
+  "offset": 29800,              // オフセット（ミリ秒）
+  "notes": [                    // ノーツ配列
+    {
+      "LPB": 4,                // Lines Per Beat（1ビートあたりの分割数）
+      "num": 272,              // タイミング（LPB単位）
+      "block": 0,              // レーン番号（0-3）
+      "type": 2,               // ノーツタイプ（1=Tap, 2=Hold）
+      "notes": [               // Holdノーツの終了位置（type=2の場合のみ）
+        {
+          "LPB": 4,
+          "num": 288,
+          "block": 0,
+          "type": 2,
+          "notes": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+### データマッピング仕様
+
+| 外部形式フィールド | ChartDataフィールド | 変換ロジック |
+|-----------------|------------------|------------|
+| name | songName | 直接マッピング |
+| BPM | bpm | 直接マッピング |
+| offset | firstBeatOffset | ミリ秒→秒→ビート単位への変換 |
+| notes[].block | NoteData.laneIndex | 直接マッピング（0-3） |
+| notes[].type | NoteData.noteType | 1→Tap, 2→Hold |
+| notes[].num | NoteData.timeToHit | num / LPB（ビート単位） |
+| notes[].notes | NoteData.holdDuration | (終了num - 開始num) / LPB |
+
+## システムアーキテクチャ
+
+### クラス構造
+
+```mermaid
+classDiagram
+    class ChartEditorWindow {
+        -ChartData _currentChart
+        +ImportFromExternalJSON()
+        +ShowImportDialog()
+    }
+    
+    class ChartImportManager {
+        +ImportChart(string json, ImportFormat format) ChartData
+        -DetectFormat(string json) ImportFormat
+        -ValidateImportData(object data) bool
+    }
+    
+    class IChartImporter {
+        <<interface>>
+        +CanImport(string json) bool
+        +Import(string json) ChartData
+        +GetFormatName() string
+    }
+    
+    class NotesEditorJsonImporter {
+        +CanImport(string json) bool
+        +Import(string json) ChartData
+        -ConvertToChartData(NotesEditorData data) ChartData
+        -CalculateHoldDuration(NotesEditorNote note) float
+    }
+    
+    class NotesEditorData {
+        +string name
+        +int maxBlock
+        +float BPM
+        +int offset
+        +List~NotesEditorNote~ notes
+    }
+    
+    class NotesEditorNote {
+        +int LPB
+        +int num
+        +int block
+        +int type
+        +List~NotesEditorNote~ notes
+    }
+    
+    ChartEditorWindow --> ChartImportManager
+    ChartImportManager --> IChartImporter
+    NotesEditorJsonImporter ..|> IChartImporter
+    NotesEditorJsonImporter --> NotesEditorData
+    NotesEditorData --> NotesEditorNote
+```
+
+### データフロー
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ChartEditor
+    participant ImportManager
+    participant Importer
+    participant ChartData
+    
+    User->>ChartEditor: JSONファイル選択
+    ChartEditor->>ImportManager: ImportChart(json)
+    ImportManager->>ImportManager: DetectFormat(json)
+    ImportManager->>Importer: Import(json)
+    Importer->>Importer: Parse JSON
+    Importer->>Importer: Validate Data
+    Importer->>Importer: Convert to ChartData
+    Importer->>ChartData: Create/Update
+    ChartData-->>ChartEditor: Return ChartData
+    ChartEditor-->>User: インポート完了
+```
+
+## 詳細設計
+
+### NotesEditorJsonImporter クラス
+
+```csharp
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// NotesEditor形式のJSONインポーター
+    /// </summary>
+    public class NotesEditorJsonImporter : IChartImporter
+    {
+        public string GetFormatName() => "NotesEditor JSON";
+        
+        public bool CanImport(string json)
+        {
+            try
+            {
+                var data = JsonUtility.FromJson<NotesEditorData>(json);
+                return data != null && 
+                       data.notes != null && 
+                       !string.IsNullOrEmpty(data.name);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        
+        public ChartData Import(string json)
+        {
+            var NotesEditorData = ParseJson(json);
+            ValidateData(NotesEditorData);
+            return ConvertToChartData(NotesEditorData);
+        }
+        
+        private NotesEditorData ParseJson(string json)
+        {
+            var data = JsonUtility.FromJson<NotesEditorData>(json);
+            if (data == null)
+            {
+                throw new ImportException("JSONの解析に失敗しました");
+            }
+            return data;
+        }
+        
+        private void ValidateData(NotesEditorData data)
+        {
+            if (data.BPM <= 0)
+            {
+                throw new ImportException($"無効なBPM値: {data.BPM}");
+            }
+            
+            if (data.notes == null)
+            {
+                throw new ImportException("ノーツデータが存在しません");
+            }
+            
+            foreach (var note in data.notes)
+            {
+                if (note.block < 0 || note.block > 3)
+                {
+                    throw new ImportException($"無効なレーン番号: {note.block}");
+                }
+                
+                if (note.type != 1 && note.type != 2)
+                {
+                    throw new ImportException($"無効なノーツタイプ: {note.type}");
+                }
+            }
+        }
+        
+        private ChartData ConvertToChartData(NotesEditorData data)
+        {
+            var chartData = ScriptableObject.CreateInstance<ChartData>();
+            
+            // 基本情報の設定
+            SetChartMetadata(chartData, data);
+            
+            // ノーツデータの変換
+            ConvertNotes(chartData, data);
+            
+            // ソートと検証
+            chartData.SortNotesByTime();
+            
+            return chartData;
+        }
+        
+        private void SetChartMetadata(ChartData chartData, NotesEditorData data)
+        {
+            // ChartDataのプロパティ設定（リフレクションまたはSerializedObjectを使用）
+            var so = new SerializedObject(chartData);
+            
+            so.FindProperty("_songName").stringValue = data.name;
+            so.FindProperty("_bpm").floatValue = data.BPM;
+            so.FindProperty("_firstBeatOffset").floatValue = ConvertOffsetToBeats(data.offset, data.BPM);
+            so.FindProperty("_difficulty").intValue = 5; // デフォルト値
+            so.FindProperty("_difficultyName").stringValue = "Normal";
+            
+            so.ApplyModifiedProperties();
+        }
+        
+        private float ConvertOffsetToBeats(int offsetMs, float bpm)
+        {
+            // ミリ秒をビート単位に変換
+            float offsetSeconds = offsetMs / 1000f;
+            float beatDuration = 60f / bpm;
+            return offsetSeconds / beatDuration;
+        }
+        
+        private void ConvertNotes(ChartData chartData, NotesEditorData data)
+        {
+            chartData.Notes.Clear();
+            
+            foreach (var NotesEditorNote in data.notes)
+            {
+                var noteData = ConvertNote(NotesEditorNote);
+                if (noteData != null)
+                {
+                    chartData.Notes.Add(noteData);
+                }
+            }
+        }
+        
+        private NoteData ConvertNote(NotesEditorNote notesEditorNote)
+        {
+            var noteData = new NoteData();
+            
+            // 基本プロパティの設定
+            noteData.LaneIndex = NotesEditorNote.block;
+            noteData.NoteType = NotesEditorNote.type == 1 ? NoteType.Tap : NoteType.Hold;
+            noteData.TimeToHit = (float)NotesEditorNote.num / NotesEditorNote.LPB;
+            
+            // Holdノーツの場合、duration計算
+            if (noteData.NoteType == NoteType.Hold && NotesEditorNote.notes != null && NotesEditorNote.notes.Count > 0)
+            {
+                var endNote = NotesEditorNote.notes[0];
+                float NotesEditor = (float)endNote.num / endNote.LPB;
+                noteData.HoldDuration = NotesEditor - noteData.TimeToHit;
+            }
+            
+            // デフォルト値の設定
+            noteData.VisualScale = 1.0f;
+            noteData.NoteColor = Color.white;
+            noteData.BaseScore = 100;
+            noteData.ScoreMultiplier = 1.0f;
+            
+            return noteData;
+        }
+    }
+}
+```
+
+### ChartImportManager クラス
+
+```csharp
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// 譜面インポート管理クラス
+    /// </summary>
+    public static class ChartImportManager
+    {
+        private static readonly List<IChartImporter> importers = new List<IChartImporter>
+        {
+            new NotesEditorJsonImporter(),
+            // 将来的に他のインポーターを追加
+        };
+        
+        public static bool TryImport(string json, out ChartData chartData, out string error)
+        {
+            chartData = null;
+            error = null;
+            
+            foreach (var importer in importers)
+            {
+                if (importer.CanImport(json))
+                {
+                    try
+                    {
+                        chartData = importer.Import(json);
+                        return true;
+                    }
+                    catch (Exception e)
+                    {
+                        error = $"{importer.GetFormatName()}のインポート失敗: {e.Message}";
+                        Debug.LogError(error);
+                    }
+                }
+            }
+            
+            error = "対応するインポート形式が見つかりませんでした";
+            return false;
+        }
+        
+        public static string[] GetSupportedFormats()
+        {
+            return importers.Select(i => i.GetFormatName()).ToArray();
+        }
+    }
+}
+```
+
+## エラーハンドリング
+
+### エラーの種類と対処
+
+| エラー種別 | 説明 | 対処方法 |
+|----------|------|---------|
+| JSONパースエラー | JSON構文が不正 | エラーメッセージ表示、インポート中止 |
+| フォーマット不一致 | 必須フィールドの欠如 | 対応フォーマット候補を提示 |
+| データ検証エラー | 値の範囲外、不正な値 | 詳細なエラー内容を表示 |
+| 変換エラー | データ変換中の例外 | ログ記録、部分的なインポート |
+
+### エラー時のフォールバック
+
+```csharp
+public class ImportFallbackHandler
+{
+    public static ChartData CreateFallbackChart(string name, float bpm)
+    {
+        var chartData = ScriptableObject.CreateInstance<ChartData>();
+        
+        // 最小限の情報で譜面を作成
+        var so = new SerializedObject(chartData);
+        so.FindProperty("_songName").stringValue = name ?? "Imported Chart";
+        so.FindProperty("_bpm").floatValue = bpm > 0 ? bpm : 120f;
+        so.ApplyModifiedProperties();
+        
+        return chartData;
+    }
+    
+    public static void LogImportWarnings(List<string> warnings)
+    {
+        if (warnings.Count > 0)
+        {
+            Debug.LogWarning($"インポート時の警告 ({warnings.Count}件):");
+            foreach (var warning in warnings)
+            {
+                Debug.LogWarning($"  - {warning}");
+            }
+        }
+    }
+}
+```
+
+## UI/UX設計
+
+### インポートダイアログの改善
+
+```csharp
+public class ImportDialog : EditorWindow
+{
+    private string jsonPreview;
+    private ImportFormat detectedFormat;
+    private List<string> validationMessages;
+    
+    public static void ShowDialog(string json)
+    {
+        var window = GetWindow<ImportDialog>("譜面インポート");
+        window.jsonPreview = json;
+        window.AnalyzeJson();
+    }
+    
+    void OnGUI()
+    {
+        EditorGUILayout.LabelField("インポート形式", detectedFormat.ToString());
+        
+        // JSON プレビュー（折りたたみ可能）
+        DrawJsonPreview();
+        
+        // 検証結果の表示
+        DrawValidationResults();
+        
+        // インポートボタン
+        DrawImportButtons();
+    }
+}
+```
+
+### プログレス表示
+
+```csharp
+public class ImportProgressReporter
+{
+    public static void ShowProgress(string title, string info, float progress)
+    {
+        EditorUtility.DisplayProgressBar(title, info, progress);
+    }
+    
+    public static void ReportNoteConversion(int current, int total)
+    {
+        float progress = (float)current / total;
+        ShowProgress("譜面インポート中", 
+                    $"ノーツを変換中... ({current}/{total})", 
+                    progress);
+    }
+}
+```
+
+## パフォーマンス最適化
+
+### 大量ノーツデータの処理
+
+```csharp
+public class BatchNoteConverter
+{
+    private const int BATCH_SIZE = 100;
+    
+    public IEnumerator ConvertNotesAsync(
+        List<NotesEditorNote> sourceNotes, 
+        ChartData targetChart,
+        Action<float> onProgress)
+    {
+        int totalNotes = sourceNotes.Count;
+        int processed = 0;
+        
+        for (int i = 0; i < totalNotes; i += BATCH_SIZE)
+        {
+            int batchEnd = Mathf.Min(i + BATCH_SIZE, totalNotes);
+            
+            // バッチ処理
+            for (int j = i; j < batchEnd; j++)
+            {
+                var noteData = ConvertNote(sourceNotes[j]);
+                targetChart.Notes.Add(noteData);
+                processed++;
+            }
+            
+            // 進捗報告
+            onProgress?.Invoke((float)processed / totalNotes);
+            
+            // フレーム譲渡
+            yield return null;
+        }
+    }
+}
+```
+
+### メモリ使用量の最適化
+
+```csharp
+public class MemoryOptimizedImporter
+{
+    public ChartData ImportLargeFile(string filePath)
+    {
+        using (var reader = new StreamReader(filePath))
+        using (var jsonReader = new JsonTextReader(reader))
+        {
+            // ストリーミング処理でメモリ使用量を削減
+            var serializer = new JsonSerializer();
+            var data = serializer.Deserialize<NotesEditorData>(jsonReader);
+            return ConvertToChartData(data);
+        }
+    }
+}
+```
+
+## テスト計画
+
+### ユニットテスト
+
+```csharp
+[TestFixture]
+public class NotesEditorJsonImporterTests
+{
+    [Test]
+    public void TestBasicImport()
+    {
+        string json = @"{
+            ""name"": ""Test Song"",
+            ""BPM"": 120,
+            ""offset"": 0,
+            ""notes"": []
+        }";
+        
+        var importer = new NotesEditorJsonImporter();
+        Assert.IsTrue(importer.CanImport(json));
+        
+        var chartData = importer.Import(json);
+        Assert.AreEqual("Test Song", chartData.SongName);
+        Assert.AreEqual(120f, chartData.Bpm);
+    }
+    
+    [Test]
+    public void TestNoteConversion()
+    {
+        var notesEditorNote = new NotesEditorNote
+        {
+            LPB = 4,
+            num = 16,
+            block = 2,
+            type = 1
+        };
+        
+        var noteData = ConvertNote(NotesEditorNote);
+        Assert.AreEqual(4f, noteData.TimeToHit); // 16 / 4 = 4
+        Assert.AreEqual(2, noteData.LaneIndex);
+        Assert.AreEqual(NoteType.Tap, noteData.NoteType);
+    }
+    
+    [Test]
+    public void TestHoldNoteConversion()
+    {
+        var holdNote = new NotesEditorNote
+        {
+            LPB = 4,
+            num = 8,
+            block = 1,
+            type = 2,
+            notes = new List<NotesEditorNote>
+            {
+                new NotesEditorNote { LPB = 4, num = 16, block = 1, type = 2 }
+            }
+        };
+        
+        var noteData = ConvertNote(holdNote);
+        Assert.AreEqual(NoteType.Hold, noteData.NoteType);
+        Assert.AreEqual(2f, noteData.HoldDuration); // (16-8)/4 = 2
+    }
+}
+```
+
+### 統合テスト
+
+1. **実ファイルインポートテスト**
+   - End_Time.jsonの完全なインポート
+   - 全ノーツの正確な変換確認
+   - パフォーマンス測定
+
+2. **エラーハンドリングテスト**
+   - 不正なJSONファイル
+   - 欠損データの処理
+   - 大容量ファイルの処理
+
+3. **互換性テスト**
+   - 異なるバージョンのJSON形式
+   - 拡張フィールドの処理
+   - 後方互換性の確保
+
+## セキュリティ考慮事項
+
+### 入力検証
+
+```csharp
+public class ImportSecurityValidator
+{
+    private const int MAX_FILE_SIZE_MB = 10;
+    private const int MAX_NOTES_COUNT = 10000;
+    
+    public static bool ValidateFileSize(string filePath)
+    {
+        var fileInfo = new FileInfo(filePath);
+        return fileInfo.Length <= MAX_FILE_SIZE_MB * 1024 * 1024;
+    }
+    
+    public static bool ValidateNoteCount(int count)
+    {
+        return count <= MAX_NOTES_COUNT;
+    }
+    
+    public static string SanitizeString(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return "";
+            
+        // 危険な文字を除去
+        return Regex.Replace(input, @"[<>""']", "");
+    }
+}
+```
+
+## 拡張性
+
+### 新しいインポート形式の追加
+
+```csharp
+// 例: osu!形式のインポーター
+public class OsuBeatmapImporter : IChartImporter
+{
+    public string GetFormatName() => "osu! Beatmap";
+    
+    public bool CanImport(string content)
+    {
+        return content.Contains("osu file format");
+    }
+    
+    public ChartData Import(string content)
+    {
+        // osu!形式の解析と変換
+        var beatmap = ParseOsuBeatmap(content);
+        return ConvertToChartData(beatmap);
+    }
+}
+```
+
+### プラグインシステム
+
+```csharp
+public interface IImportPlugin
+{
+    string Name { get; }
+    string Version { get; }
+    string[] SupportedExtensions { get; }
+    IChartImporter CreateImporter();
+}
+
+public class ImportPluginManager
+{
+    private static List<IImportPlugin> plugins = new List<IImportPlugin>();
+    
+    public static void RegisterPlugin(IImportPlugin plugin)
+    {
+        plugins.Add(plugin);
+        Debug.Log($"インポートプラグイン登録: {plugin.Name} v{plugin.Version}");
+    }
+}
+```
+
+## まとめ
+
+本設計により、外部JSON形式の譜面データを柔軟にインポートできる拡張可能なシステムを実現します。End_Time.json形式を第一の対応フォーマットとし、将来的な拡張にも対応可能な設計となっています。

--- a/docs/architectures/chart-editor-json-import-implementation-plan.md
+++ b/docs/architectures/chart-editor-json-import-implementation-plan.md
@@ -1,0 +1,1004 @@
+# ChartEditor JSON インポート機能 実装計画書
+
+## 概要
+
+本書は、ChartEditor JSON インポート機能の段階的な実装計画を定義します。NotesEditor形式の譜面データをJirouプロジェクトにインポートできるようにする機能を、リスクを最小限に抑えながら実装します。
+
+## 実装スケジュール
+
+### フェーズ1: 基盤構築（1-2日）
+- データモデルクラスの実装
+- 基本的な変換ロジックの実装
+- ユニットテストの作成
+
+### フェーズ2: インポート機能実装（2-3日）
+- IChartImporterインターフェースの実装
+- NotesEditorJsonImporterクラスの実装
+- ChartImportManagerの実装
+
+### フェーズ3: UI統合（1-2日）
+- ChartEditorWindowへの統合
+- エラーハンドリングとユーザーフィードバック
+- プログレス表示の実装
+
+### フェーズ4: テストと最適化（1-2日）
+- 統合テストの実施
+- パフォーマンス最適化
+- ドキュメント作成
+
+## フェーズ1: 基盤構築
+
+### 1.1 データモデルクラスの作成
+
+**ファイル**: `Assets/_Jirou/Scripts/Editor/Import/NotesEditorData.cs`
+
+```csharp
+using System;
+using System.Collections.Generic;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// NotesEditor形式のJSONデータ構造
+    /// </summary>
+    [Serializable]
+    public class NotesEditorData
+    {
+        public string name;           // 曲名
+        public int maxBlock;         // 最大ブロック数
+        public float BPM;            // BPM
+        public int offset;           // オフセット（ミリ秒）
+        public List<NotesEditorNote> notes;  // ノーツリスト
+    }
+    
+    /// <summary>
+    /// NotesEditor形式のノーツデータ
+    /// </summary>
+    [Serializable]
+    public class NotesEditorNote
+    {
+        public int LPB;              // Lines Per Beat
+        public int num;              // タイミング（LPB単位）
+        public int block;            // レーン番号（0-3）
+        public int type;             // ノーツタイプ（1=Tap, 2=Hold）
+        public List<NotesEditorNote> notes;  // Holdノーツの終了位置
+    }
+}
+```
+
+### 1.2 基本変換ユーティリティの作成
+
+**ファイル**: `Assets/_Jirou/Scripts/Editor/Import/ChartConversionUtility.cs`
+
+```csharp
+using UnityEngine;
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// 譜面データ変換ユーティリティ
+    /// </summary>
+    public static class ChartConversionUtility
+    {
+        /// <summary>
+        /// ミリ秒オフセットをビート単位に変換
+        /// </summary>
+        public static float ConvertMillisecondsToBeats(int offsetMs, float bpm)
+        {
+            if (bpm <= 0) return 0f;
+            
+            float offsetSeconds = offsetMs / 1000f;
+            float beatDuration = 60f / bpm;
+            return offsetSeconds / beatDuration;
+        }
+        
+        /// <summary>
+        /// LPB単位のタイミングをビート単位に変換
+        /// </summary>
+        public static float ConvertLPBToBeats(int num, int lpb)
+        {
+            if (lpb <= 0) return 0f;
+            return (float)num / lpb;
+        }
+        
+        /// <summary>
+        /// ノーツタイプを変換
+        /// </summary>
+        public static NoteType ConvertNoteType(int type)
+        {
+            return type == 2 ? NoteType.Hold : NoteType.Tap;
+        }
+        
+        /// <summary>
+        /// Holdノーツの継続時間を計算
+        /// </summary>
+        public static float CalculateHoldDuration(NotesEditorNote startNote)
+        {
+            if (startNote.type != 2 || startNote.notes == null || startNote.notes.Count == 0)
+            {
+                return 0f;
+            }
+            
+            var endNote = startNote.notes[0];
+            float startTime = ConvertLPBToBeats(startNote.num, startNote.LPB);
+            float endTime = ConvertLPBToBeats(endNote.num, endNote.LPB);
+            
+            return endTime - startTime;
+        }
+    }
+}
+```
+
+### 1.3 ユニットテストの作成
+
+**ファイル**: `Assets/Tests/EditMode/Import/ChartConversionUtilityTests.cs`
+
+```csharp
+using NUnit.Framework;
+using Jirou.Editor.Import;
+using Jirou.Core;
+
+namespace Jirou.Tests.Editor
+{
+    [TestFixture]
+    public class ChartConversionUtilityTests
+    {
+        [Test]
+        public void ConvertMillisecondsToBeats_正常な変換()
+        {
+            // BPM 120の場合、1ビート = 0.5秒 = 500ms
+            float result = ChartConversionUtility.ConvertMillisecondsToBeats(1000, 120f);
+            Assert.AreEqual(2f, result, 0.001f);
+        }
+        
+        [Test]
+        public void ConvertLPBToBeats_正常な変換()
+        {
+            // num=16, LPB=4 の場合、16/4 = 4ビート
+            float result = ChartConversionUtility.ConvertLPBToBeats(16, 4);
+            Assert.AreEqual(4f, result, 0.001f);
+        }
+        
+        [Test]
+        public void ConvertNoteType_Tapノーツ()
+        {
+            var result = ChartConversionUtility.ConvertNoteType(1);
+            Assert.AreEqual(NoteType.Tap, result);
+        }
+        
+        [Test]
+        public void ConvertNoteType_Holdノーツ()
+        {
+            var result = ChartConversionUtility.ConvertNoteType(2);
+            Assert.AreEqual(NoteType.Hold, result);
+        }
+    }
+}
+```
+
+## フェーズ2: インポート機能実装
+
+### 2.1 インポーターインターフェースの定義
+
+**ファイル**: `Assets/_Jirou/Scripts/Editor/Import/IChartImporter.cs`
+
+```csharp
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// 譜面インポーターのインターフェース
+    /// </summary>
+    public interface IChartImporter
+    {
+        /// <summary>
+        /// フォーマット名を取得
+        /// </summary>
+        string GetFormatName();
+        
+        /// <summary>
+        /// このインポーターが対応可能か判定
+        /// </summary>
+        bool CanImport(string content);
+        
+        /// <summary>
+        /// インポート実行
+        /// </summary>
+        ChartData Import(string content);
+    }
+}
+```
+
+### 2.2 NotesEditorJsonImporterの実装
+
+**ファイル**: `Assets/_Jirou/Scripts/Editor/Import/NotesEditorJsonImporter.cs`
+
+```csharp
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// NotesEditor形式のJSONインポーター
+    /// </summary>
+    public class NotesEditorJsonImporter : IChartImporter
+    {
+        public string GetFormatName() => "NotesEditor JSON";
+        
+        public bool CanImport(string json)
+        {
+            try
+            {
+                var data = JsonUtility.FromJson<NotesEditorData>(json);
+                return data != null && 
+                       data.notes != null && 
+                       !string.IsNullOrEmpty(data.name);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        
+        public ChartData Import(string json)
+        {
+            // JSONをパース
+            var notesEditorData = ParseJson(json);
+            
+            // データを検証
+            ValidateData(notesEditorData);
+            
+            // ChartDataに変換
+            return ConvertToChartData(notesEditorData);
+        }
+        
+        private NotesEditorData ParseJson(string json)
+        {
+            try
+            {
+                var data = JsonUtility.FromJson<NotesEditorData>(json);
+                if (data == null)
+                {
+                    throw new ImportException("JSONの解析に失敗しました");
+                }
+                return data;
+            }
+            catch (Exception e)
+            {
+                throw new ImportException($"JSONパースエラー: {e.Message}");
+            }
+        }
+        
+        private void ValidateData(NotesEditorData data)
+        {
+            var errors = new List<string>();
+            
+            // BPMの検証
+            if (data.BPM <= 0 || data.BPM > 999)
+            {
+                errors.Add($"無効なBPM値: {data.BPM}");
+            }
+            
+            // ノーツの検証
+            if (data.notes == null)
+            {
+                errors.Add("ノーツデータが存在しません");
+            }
+            else
+            {
+                foreach (var note in data.notes)
+                {
+                    if (note.block < 0 || note.block > 3)
+                    {
+                        errors.Add($"無効なレーン番号: {note.block} (タイミング: {note.num})");
+                    }
+                    
+                    if (note.type != 1 && note.type != 2)
+                    {
+                        errors.Add($"無効なノーツタイプ: {note.type} (タイミング: {note.num})");
+                    }
+                    
+                    if (note.LPB <= 0)
+                    {
+                        errors.Add($"無効なLPB値: {note.LPB} (タイミング: {note.num})");
+                    }
+                }
+            }
+            
+            if (errors.Count > 0)
+            {
+                throw new ImportException(string.Join("\n", errors));
+            }
+        }
+        
+        private ChartData ConvertToChartData(NotesEditorData data)
+        {
+            // 新しいChartDataアセットを作成
+            var chartData = ScriptableObject.CreateInstance<ChartData>();
+            
+            // SerializedObjectを使用してプライベートフィールドを設定
+            var so = new SerializedObject(chartData);
+            
+            try
+            {
+                // 基本情報の設定
+                SetChartMetadata(so, data);
+                
+                // ノーツデータの変換と追加
+                ConvertAndAddNotes(chartData, data.notes);
+                
+                // 変更を適用
+                so.ApplyModifiedPropertiesWithoutUndo();
+                
+                // ノーツをソート
+                chartData.SortNotesByTime();
+                
+                return chartData;
+            }
+            catch (Exception e)
+            {
+                // エラー時はアセットを破棄
+                UnityEngine.Object.DestroyImmediate(chartData);
+                throw new ImportException($"ChartData変換エラー: {e.Message}");
+            }
+        }
+        
+        private void SetChartMetadata(SerializedObject so, NotesEditorData data)
+        {
+            // 基本情報の設定
+            so.FindProperty("_songName").stringValue = data.name;
+            so.FindProperty("_bpm").floatValue = data.BPM;
+            
+            // オフセットをビート単位に変換
+            float offsetBeats = ChartConversionUtility.ConvertMillisecondsToBeats(data.offset, data.BPM);
+            so.FindProperty("_firstBeatOffset").floatValue = offsetBeats;
+            
+            // デフォルト値の設定
+            so.FindProperty("_artist").stringValue = "Unknown Artist";
+            so.FindProperty("_difficulty").intValue = 5;
+            so.FindProperty("_difficultyName").stringValue = "Normal";
+            so.FindProperty("_chartAuthor").stringValue = "Imported";
+            so.FindProperty("_chartVersion").stringValue = "1.0";
+        }
+        
+        private void ConvertAndAddNotes(ChartData chartData, List<NotesEditorNote> notesEditorNotes)
+        {
+            chartData.Notes.Clear();
+            
+            foreach (var notesEditorNote in notesEditorNotes)
+            {
+                var noteData = ConvertNote(notesEditorNote);
+                if (noteData != null)
+                {
+                    chartData.Notes.Add(noteData);
+                }
+            }
+            
+            Debug.Log($"インポート完了: {chartData.Notes.Count}個のノーツを変換しました");
+        }
+        
+        private NoteData ConvertNote(NotesEditorNote notesEditorNote)
+        {
+            var noteData = new NoteData();
+            
+            // 基本プロパティの設定
+            noteData.LaneIndex = notesEditorNote.block;
+            noteData.NoteType = ChartConversionUtility.ConvertNoteType(notesEditorNote.type);
+            noteData.TimeToHit = ChartConversionUtility.ConvertLPBToBeats(notesEditorNote.num, notesEditorNote.LPB);
+            
+            // Holdノーツの場合、duration計算
+            if (noteData.NoteType == NoteType.Hold)
+            {
+                noteData.HoldDuration = ChartConversionUtility.CalculateHoldDuration(notesEditorNote);
+            }
+            
+            // デフォルト値の設定
+            noteData.VisualScale = 1.0f;
+            noteData.NoteColor = Color.white;
+            noteData.BaseScore = 100;
+            noteData.ScoreMultiplier = 1.0f;
+            
+            return noteData;
+        }
+    }
+    
+    /// <summary>
+    /// インポート例外クラス
+    /// </summary>
+    public class ImportException : Exception
+    {
+        public ImportException(string message) : base(message) { }
+    }
+}
+```
+
+### 2.3 ChartImportManagerの実装
+
+**ファイル**: `Assets/_Jirou/Scripts/Editor/Import/ChartImportManager.cs`
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// 譜面インポート管理クラス
+    /// </summary>
+    public static class ChartImportManager
+    {
+        private static readonly List<IChartImporter> importers = new List<IChartImporter>();
+        
+        static ChartImportManager()
+        {
+            // インポーターを登録
+            RegisterImporter(new NotesEditorJsonImporter());
+            // 将来的に他のインポーターも追加
+        }
+        
+        /// <summary>
+        /// インポーターを登録
+        /// </summary>
+        public static void RegisterImporter(IChartImporter importer)
+        {
+            if (importer != null && !importers.Contains(importer))
+            {
+                importers.Add(importer);
+                Debug.Log($"インポーター登録: {importer.GetFormatName()}");
+            }
+        }
+        
+        /// <summary>
+        /// インポートを試行
+        /// </summary>
+        public static bool TryImport(string content, out ChartData chartData, out string error)
+        {
+            chartData = null;
+            error = null;
+            
+            // 対応可能なインポーターを探す
+            foreach (var importer in importers)
+            {
+                if (importer.CanImport(content))
+                {
+                    try
+                    {
+                        Debug.Log($"{importer.GetFormatName()}形式として認識しました");
+                        chartData = importer.Import(content);
+                        return true;
+                    }
+                    catch (Exception e)
+                    {
+                        error = $"{importer.GetFormatName()}のインポート失敗:\n{e.Message}";
+                        Debug.LogError(error);
+                    }
+                }
+            }
+            
+            // 対応するインポーターが見つからない場合
+            error = "対応するインポート形式が見つかりませんでした。\n" +
+                   $"対応形式: {string.Join(", ", GetSupportedFormats())}";
+            return false;
+        }
+        
+        /// <summary>
+        /// サポートされている形式を取得
+        /// </summary>
+        public static string[] GetSupportedFormats()
+        {
+            return importers.Select(i => i.GetFormatName()).ToArray();
+        }
+        
+        /// <summary>
+        /// フォーマットを自動検出
+        /// </summary>
+        public static string DetectFormat(string content)
+        {
+            foreach (var importer in importers)
+            {
+                if (importer.CanImport(content))
+                {
+                    return importer.GetFormatName();
+                }
+            }
+            return "Unknown";
+        }
+    }
+}
+```
+
+## フェーズ3: UI統合
+
+### 3.1 ChartEditorWindowの修正
+
+**修正箇所**: `ImportFromJSON()`メソッドを更新
+
+```csharp
+private void ImportFromJSON()
+{
+    string path = GetImportPath();
+        
+    if (!string.IsNullOrEmpty(path))
+    {
+        try
+        {
+            string content = System.IO.File.ReadAllText(path);
+            
+            // 形式を検出
+            string format = ChartImportManager.DetectFormat(content);
+            
+            // 確認ダイアログ
+            if (EditorUtility.DisplayDialog("インポート確認",
+                $"検出された形式: {format}\n" +
+                $"現在の譜面データは上書きされます。続行しますか？",
+                "インポート", "キャンセル"))
+            {
+                ImportWithManager(content, path);
+            }
+        }
+        catch (System.Exception e)
+        {
+            HandleImportError(e);
+        }
+    }
+}
+
+private void ImportWithManager(string content, string path)
+{
+    ChartData importedChart;
+    string error;
+    
+    // プログレスバー表示
+    EditorUtility.DisplayProgressBar("インポート中", "譜面データを変換しています...", 0.5f);
+    
+    try
+    {
+        if (ChartImportManager.TryImport(content, out importedChart, out error))
+        {
+            // インポート成功
+            ApplyImportedChartData(importedChart);
+            ShowImportSuccessDialog(path, importedChart.Notes.Count);
+        }
+        else
+        {
+            // インポート失敗
+            EditorUtility.DisplayDialog("インポートエラー", error, "OK");
+        }
+    }
+    finally
+    {
+        EditorUtility.ClearProgressBar();
+    }
+}
+
+private void ApplyImportedChartData(ChartData importedChart)
+{
+    if (importedChart == null) return;
+    
+    Undo.RecordObject(_currentChart, "Import Chart");
+    
+    // ノーツデータをコピー
+    _currentChart.Notes.Clear();
+    _currentChart.Notes.AddRange(importedChart.Notes);
+    
+    // メタデータの更新（可能な範囲で）
+    // 注: SerializedPropertyを使用する必要がある場合がある
+    
+    EditorUtility.SetDirty(_currentChart);
+    
+    // インポートしたChartDataインスタンスを破棄
+    UnityEngine.Object.DestroyImmediate(importedChart);
+}
+```
+
+### 3.2 インポートダイアログの作成
+
+**ファイル**: `Assets/_Jirou/Scripts/Editor/Import/ImportPreviewDialog.cs`
+
+```csharp
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using Jirou.Core;
+
+namespace Jirou.Editor.Import
+{
+    /// <summary>
+    /// インポートプレビューダイアログ
+    /// </summary>
+    public class ImportPreviewDialog : EditorWindow
+    {
+        private string jsonContent;
+        private string detectedFormat;
+        private ChartData previewData;
+        private Vector2 scrollPosition;
+        private bool showJsonContent = false;
+        private List<string> validationMessages = new List<string>();
+        
+        public static void ShowDialog(string json, System.Action<ChartData> onImport)
+        {
+            var window = GetWindow<ImportPreviewDialog>("譜面インポート プレビュー");
+            window.minSize = new Vector2(500, 400);
+            window.jsonContent = json;
+            window.AnalyzeContent();
+        }
+        
+        private void AnalyzeContent()
+        {
+            detectedFormat = ChartImportManager.DetectFormat(jsonContent);
+            
+            // プレビュー用にインポートを試行
+            string error;
+            if (ChartImportManager.TryImport(jsonContent, out previewData, out error))
+            {
+                validationMessages.Add($"✓ {previewData.Notes.Count}個のノーツを検出");
+                validationMessages.Add($"✓ BPM: {previewData.Bpm}");
+                validationMessages.Add($"✓ 曲名: {previewData.SongName}");
+            }
+            else
+            {
+                validationMessages.Add($"✗ {error}");
+            }
+        }
+        
+        void OnGUI()
+        {
+            EditorGUILayout.LabelField("インポート形式", detectedFormat);
+            EditorGUILayout.Space();
+            
+            // プレビュー情報
+            if (previewData != null)
+            {
+                DrawPreviewInfo();
+            }
+            
+            // JSONコンテンツの表示/非表示
+            showJsonContent = EditorGUILayout.Foldout(showJsonContent, "JSONコンテンツ");
+            if (showJsonContent)
+            {
+                DrawJsonContent();
+            }
+            
+            // 検証結果
+            DrawValidationResults();
+            
+            // ボタン
+            DrawButtons();
+        }
+        
+        private void DrawPreviewInfo()
+        {
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+            EditorGUILayout.LabelField("譜面情報プレビュー", EditorStyles.boldLabel);
+            
+            EditorGUILayout.LabelField($"曲名: {previewData.SongName}");
+            EditorGUILayout.LabelField($"BPM: {previewData.Bpm}");
+            EditorGUILayout.LabelField($"ノーツ数: {previewData.Notes.Count}");
+            
+            var stats = previewData.GetStatistics();
+            EditorGUILayout.LabelField($"Tapノーツ: {stats.tapNotes}");
+            EditorGUILayout.LabelField($"Holdノーツ: {stats.holdNotes}");
+            
+            EditorGUILayout.EndVertical();
+        }
+        
+        private void DrawJsonContent()
+        {
+            scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition, GUILayout.Height(150));
+            EditorGUILayout.TextArea(jsonContent, GUILayout.ExpandHeight(true));
+            EditorGUILayout.EndScrollView();
+        }
+        
+        private void DrawValidationResults()
+        {
+            if (validationMessages.Count > 0)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("検証結果", EditorStyles.boldLabel);
+                
+                foreach (var msg in validationMessages)
+                {
+                    var style = msg.StartsWith("✓") ? EditorStyles.label : EditorStyles.helpBox;
+                    EditorGUILayout.LabelField(msg, style);
+                }
+            }
+        }
+        
+        private void DrawButtons()
+        {
+            EditorGUILayout.Space();
+            EditorGUILayout.BeginHorizontal();
+            
+            GUI.enabled = previewData != null;
+            if (GUILayout.Button("インポート", GUILayout.Height(30)))
+            {
+                // インポート実行
+                Close();
+            }
+            GUI.enabled = true;
+            
+            if (GUILayout.Button("キャンセル", GUILayout.Height(30)))
+            {
+                if (previewData != null)
+                {
+                    DestroyImmediate(previewData);
+                }
+                Close();
+            }
+            
+            EditorGUILayout.EndHorizontal();
+        }
+    }
+}
+```
+
+## フェーズ4: テストと最適化
+
+### 4.1 統合テストの作成
+
+**ファイル**: `Assets/Tests/EditMode/Import/NotesEditorImportIntegrationTests.cs`
+
+```csharp
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEditor;
+using Jirou.Core;
+using Jirou.Editor.Import;
+
+namespace Jirou.Tests.Editor
+{
+    [TestFixture]
+    public class NotesEditorImportIntegrationTests
+    {
+        private string testDataPath;
+        
+        [SetUp]
+        public void Setup()
+        {
+            // テストデータのパスを設定
+            testDataPath = Path.Combine(Application.dataPath, 
+                "_Jirou/Data/ChartsJson/End_Time.json");
+        }
+        
+        [Test]
+        public void ImportNotesEditorJson_完全なファイル()
+        {
+            // ファイルが存在することを確認
+            Assert.IsTrue(File.Exists(testDataPath), 
+                $"テストファイルが見つかりません: {testDataPath}");
+            
+            // JSONを読み込み
+            string json = File.ReadAllText(testDataPath);
+            
+            // インポート実行
+            ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(json, out chartData, out error);
+            
+            // 検証
+            Assert.IsTrue(success, $"インポート失敗: {error}");
+            Assert.IsNotNull(chartData);
+            Assert.AreEqual("End_Time", chartData.SongName);
+            Assert.AreEqual(180f, chartData.Bpm);
+            Assert.Greater(chartData.Notes.Count, 0);
+            
+            // 後処理
+            Object.DestroyImmediate(chartData);
+        }
+        
+        [Test]
+        public void ImportNotesEditorJson_ノーツ変換確認()
+        {
+            string simpleJson = @"{
+                ""name"": ""Test"",
+                ""BPM"": 120,
+                ""offset"": 0,
+                ""notes"": [
+                    {
+                        ""LPB"": 4,
+                        ""num"": 8,
+                        ""block"": 1,
+                        ""type"": 1,
+                        ""notes"": []
+                    }
+                ]
+            }";
+            
+            ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(simpleJson, out chartData, out error);
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(1, chartData.Notes.Count);
+            
+            var note = chartData.Notes[0];
+            Assert.AreEqual(1, note.LaneIndex);
+            Assert.AreEqual(NoteType.Tap, note.NoteType);
+            Assert.AreEqual(2f, note.TimeToHit); // 8/4 = 2
+            
+            Object.DestroyImmediate(chartData);
+        }
+        
+        [Test]
+        public void ImportNotesEditorJson_Holdノーツ変換()
+        {
+            string holdJson = @"{
+                ""name"": ""Test"",
+                ""BPM"": 120,
+                ""offset"": 0,
+                ""notes"": [
+                    {
+                        ""LPB"": 4,
+                        ""num"": 0,
+                        ""block"": 2,
+                        ""type"": 2,
+                        ""notes"": [
+                            {
+                                ""LPB"": 4,
+                                ""num"": 16,
+                                ""block"": 2,
+                                ""type"": 2,
+                                ""notes"": []
+                            }
+                        ]
+                    }
+                ]
+            }";
+            
+            ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(holdJson, out chartData, out error);
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(1, chartData.Notes.Count);
+            
+            var note = chartData.Notes[0];
+            Assert.AreEqual(NoteType.Hold, note.NoteType);
+            Assert.AreEqual(4f, note.HoldDuration); // (16-0)/4 = 4
+            
+            Object.DestroyImmediate(chartData);
+        }
+    }
+}
+```
+
+### 4.2 パフォーマンステスト
+
+**ファイル**: `Assets/Tests/EditMode/Import/ImportPerformanceTests.cs`
+
+```csharp
+using System.Diagnostics;
+using NUnit.Framework;
+using Jirou.Editor.Import;
+using Debug = UnityEngine.Debug;
+
+namespace Jirou.Tests.Editor
+{
+    [TestFixture]
+    public class ImportPerformanceTests
+    {
+        [Test]
+        public void ImportLargeFile_パフォーマンス測定()
+        {
+            // 大量のノーツを含むテストデータを生成
+            var testData = GenerateLargeTestData(1000);
+            string json = JsonUtility.ToJson(testData);
+            
+            var stopwatch = Stopwatch.StartNew();
+            
+            ChartData chartData;
+            string error;
+            bool success = ChartImportManager.TryImport(json, out chartData, out error);
+            
+            stopwatch.Stop();
+            
+            Assert.IsTrue(success);
+            Assert.AreEqual(1000, chartData.Notes.Count);
+            
+            Debug.Log($"1000ノーツのインポート時間: {stopwatch.ElapsedMilliseconds}ms");
+            
+            // パフォーマンス基準: 1000ノーツで1秒以内
+            Assert.Less(stopwatch.ElapsedMilliseconds, 1000);
+            
+            UnityEngine.Object.DestroyImmediate(chartData);
+        }
+        
+        private NotesEditorData GenerateLargeTestData(int noteCount)
+        {
+            var data = new NotesEditorData
+            {
+                name = "Performance Test",
+                BPM = 120,
+                offset = 0,
+                notes = new System.Collections.Generic.List<NotesEditorNote>()
+            };
+            
+            for (int i = 0; i < noteCount; i++)
+            {
+                data.notes.Add(new NotesEditorNote
+                {
+                    LPB = 4,
+                    num = i * 4,
+                    block = i % 4,
+                    type = 1,
+                    notes = new System.Collections.Generic.List<NotesEditorNote>()
+                });
+            }
+            
+            return data;
+        }
+    }
+}
+```
+
+## 実装チェックリスト
+
+### フェーズ1
+- [ ] NotesEditorData.cs の作成
+- [ ] NotesEditorNote.cs の作成
+- [ ] ChartConversionUtility.cs の作成
+- [ ] ユニットテストの作成と実行
+
+### フェーズ2
+- [ ] IChartImporter.cs の作成
+- [ ] NotesEditorJsonImporter.cs の実装
+- [ ] ChartImportManager.cs の実装
+- [ ] 基本的な動作確認
+
+### フェーズ3
+- [ ] ChartEditorWindow.cs の修正
+- [ ] ImportPreviewDialog.cs の作成
+- [ ] UIの動作確認
+- [ ] エラーハンドリングの確認
+
+### フェーズ4
+- [ ] 統合テストの作成と実行
+- [ ] End_Time.json の完全インポートテスト
+- [ ] パフォーマンス測定
+- [ ] ドキュメントの更新
+
+## リスク管理
+
+### 技術的リスク
+
+| リスク | 影響度 | 対策 |
+|-------|--------|------|
+| SerializedObjectによるChartData更新の失敗 | 高 | 代替手段としてリフレクションを準備 |
+| 大量ノーツでのメモリ不足 | 中 | バッチ処理とストリーミング読み込み |
+| JSON形式の非互換性 | 中 | 柔軟なパーサーと詳細なエラーメッセージ |
+| Unity Editorの応答停止 | 低 | 非同期処理とプログレスバー表示 |
+
+### 運用リスク
+
+| リスク | 影響度 | 対策 |
+|-------|--------|------|
+| 誤ったファイルのインポート | 低 | フォーマット自動検出と確認ダイアログ |
+| データの上書き | 中 | Undo機能とバックアップ推奨 |
+| 不完全なデータのインポート | 中 | 詳細な検証とエラーレポート |
+
+## 今後の拡張
+
+### 追加インポート形式
+1. **osu!形式**: `.osu`ファイルのサポート
+2. **StepMania形式**: `.sm`ファイルのサポート
+3. **CSV形式**: シンプルな表形式データ
+
+### 機能拡張
+1. **バッチインポート**: 複数ファイルの一括処理
+2. **インポート履歴**: 最近インポートしたファイルの記録
+3. **カスタムマッピング**: フィールドマッピングのカスタマイズ
+4. **プレビュー再生**: インポート前の譜面プレビュー
+
+## まとめ
+
+本実装計画に従って段階的に開発を進めることで、リスクを最小限に抑えながら、NotesEditor形式の譜面データをJirouプロジェクトにインポートする機能を実現します。各フェーズでテストを実施し、品質を確保しながら開発を進めます。

--- a/docs/setup/input-system-setup-guide.md
+++ b/docs/setup/input-system-setup-guide.md
@@ -223,16 +223,16 @@
 以下を確認してください：
 
 **必須コンポーネント：**
-- [ ] Conductorが存在し、AudioClipが設定されている
-- [ ] NoteSpawnerが存在し、ChartDataまたはテスト譜面が設定されている
-- [ ] NotePoolManagerが存在し、プレハブが設定されている
-- [ ] InputManagerが存在する
-- [ ] 4つのJudgmentZoneが作成され、正しい位置にある
-- [ ] InputManagerのJudgment Zones配列に4つの判定ゾーンが設定されている
+- [x] Conductorが存在し、AudioClipが設定されている
+- [x] NoteSpawnerが存在し、ChartDataまたはテスト譜面が設定されている
+- [x] NotePoolManagerが存在し、プレハブが設定されている
+- [x] InputManagerが存在する
+- [x] 4つのJudgmentZoneが作成され、正しい位置にある
+- [x] InputManagerのJudgment Zones配列に4つの判定ゾーンが設定されている
 
 **オプション：**
-- [ ] LaneVisualizerでレーンが表示されている
-- [ ] ヒットエフェクトプレハブが作成・設定されている
+- [x] LaneVisualizerでレーンが表示されている
+- [x] ヒットエフェクトプレハブが作成・設定されている
 
 #### 5.2 Playモードでのテスト
 

--- a/docs/setup/unity-editor-setup-guide.md
+++ b/docs/setup/unity-editor-setup-guide.md
@@ -281,11 +281,11 @@ Inspectorで以下を設定：
 
 ### 9.1 再生前のチェックリスト
 
-- [ ] Conductor に AudioClip（End_Time.wav）が設定されている
-- [ ] NotePoolManager に両プレハブが設定されている
-- [ ] NoteSpawner に両プレハブが設定されている
-- [ ] LaneVisualizer のレーンが表示されている（Gizmoで確認）
-- [ ] TestSetup の Auto Setup がオンになっている
+- [x] Conductor に AudioClip（End_Time.wav）が設定されている
+- [x] NotePoolManager に両プレハブが設定されている
+- [x] NoteSpawner に両プレハブが設定されている
+- [x] LaneVisualizer のレーンが表示されている（Gizmoで確認）
+- [x] TestSetup の Auto Setup がオンになっている
 
 ### 9.2 テスト実行
 


### PR DESCRIPTION
## 概要
ChartEditorウィンドウに外部JSON形式の譜面データをインポートする機能を追加しました。
複数のJSON形式に対応可能な拡張性の高いアーキテクチャを実装し、初期実装としてnotes-editor形式のサポートを追加しています。

## 変更内容

### 新機能
- **ChartImportManager**: 複数のJSONフォーマットに対応した統合インポート管理システム
- **自動フォーマット検出**: JSONの構造を解析して適切なインポーターを自動選択
- **notes-editor形式サポート**: 外部エディタで作成された譜面データのインポート
- **インポートプレビュー**: インポート前にデータを確認できるプレビューダイアログ
- **エラーハンドリング**: 詳細なエラーメッセージとバリデーション

### 主要コンポーネント
- `IChartImporter`: インポーターの拡張可能なインターフェース
- `NotesEditorJsonImporter`: notes-editor形式の具体的な実装
- `ChartConversionUtility`: データ変換用ユーティリティ
- `ImportPreviewDialog`: プレビューUI

### テスト
- 形式検出の単体テスト
- 変換ロジックのテスト
- 統合テスト
- パフォーマンステスト

## 動作確認
1. ChartEditorウィンドウを開く（Window > Jirou > Chart Editor）
2. 「ファイル」メニューから「インポート」を選択
3. JSONファイルを選択（サンプル: `Assets/_Jirou/Data/ChartsJson/End_Time.json`）
4. 形式が自動検出され、確認ダイアログが表示される
5. 「インポート」をクリックして譜面データを読み込む

## 今後の拡張計画
- [ ] 他のJSON形式（SimaiやSusなど）のサポート追加
- [ ] エクスポート機能の実装
- [ ] バッチインポート機能
- [ ] インポート設定のカスタマイズ

## 関連ドキュメント
- [設計書](docs/architectures/chart-editor-json-import-design.md)
- [実装計画](docs/architectures/chart-editor-json-import-implementation-plan.md)

## チェックリスト
- [x] コードレビュー準備完了
- [x] テストを追加
- [x] ドキュメントを更新
- [x] Unityエディタで動作確認済み